### PR TITLE
Drop requirements from PHP 5.4.8 to 5.3

### DIFF
--- a/Lescript.php
+++ b/Lescript.php
@@ -330,10 +330,10 @@ keyUsage = nonRepudiation, digitalSignature, keyEncipherment');
         $protected["nonce"] = $this->client->getLastNonce();
 
 
-        $payload64 = Base64UrlSafeEncoder::encode(json_encode($payload, JSON_UNESCAPED_SLASHES));
+        $payload64 = Base64UrlSafeEncoder::encode(str_replace('\\/', '/', json_encode($payload)));
         $protected64 = Base64UrlSafeEncoder::encode(json_encode($protected));
 
-        openssl_sign($protected64.'.'.$payload64, $signed, $privateKey, OPENSSL_ALGO_SHA256);
+        openssl_sign($protected64.'.'.$payload64, $signed, $privateKey, "SHA256");
 
         $signed64 = Base64UrlSafeEncoder::encode($signed);
 
@@ -348,8 +348,8 @@ keyUsage = nonRepudiation, digitalSignature, keyEncipherment');
 
         return $this->client->post($uri, json_encode($data));
     }
-    
-    protected function log($message) 
+
+    protected function log($message)
     {
         if($this->logger) {
             $this->logger->info($message);

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     }
   ],
   "require": {
-    "php": ">=5.4.8",
+    "php": ">=5.3",
     "ext-curl": "*",
     "ext-openssl": "*"
   },


### PR DESCRIPTION
This PR removes the requirement for PHP 5.4.8 and drops to down to 5.3 by doing a string replace for json_encode and later telling openssl_sign to use a string instead of an INT (which is supported).

This will help systems such as Cent6.6 which are stuck in the dark ages on 5.3.x
