### PR TITLE
Made all private methods/fields protected

### DIFF
--- a/Lescript.php
+++ b/Lescript.php
@@ -13,13 +13,13 @@ class Lescript
     public $contact = array(); // optional
     // public $contact = array("mailto:cert-admin@example.com", "tel:+12025551212")
 
-    private $certificatesDir;
-    private $webRootDir;
+    protected $certificatesDir;
+    protected $webRootDir;
 
     /** @var \Psr\Log\LoggerInterface */
-    private $logger;
-    private $client;
-    private $accountKeyPath;
+    protected $logger;
+    protected $client;
+    protected $accountKeyPath;
 
     public function __construct($certificatesDir, $webRootDir, $logger = null, ClientInterface $client = null)
     {
@@ -226,7 +226,7 @@ class Lescript
         $this->log("Done !!§§!");
     }
 
-    private function readPrivateKey($path)
+    protected function readPrivateKey($path)
     {
         if (($key = openssl_pkey_get_private('file://' . $path)) === FALSE) {
             throw new \RuntimeException(openssl_error_string());
@@ -235,18 +235,18 @@ class Lescript
         return $key;
     }
 
-    private function parsePemFromBody($body)
+    protected function parsePemFromBody($body)
     {
         $pem = chunk_split(base64_encode($body), 64, "\n");
         return "-----BEGIN CERTIFICATE-----\n" . $pem . "-----END CERTIFICATE-----\n";
     }
 
-    private function getDomainPath($domain)
+    protected function getDomainPath($domain)
     {
         return $this->certificatesDir . '/' . $domain . '/';
     }
 
-    private function postNewReg()
+    protected function postNewReg()
     {
         $this->log('Sending registration to letsencrypt server');
 
@@ -261,7 +261,7 @@ class Lescript
         );
     }
 
-    private function generateCSR($privateKey, array $domains)
+    protected function generateCSR($privateKey, array $domains)
     {
         $domain = reset($domains);
         $san = implode(",", array_map(function ($dns) {
@@ -312,7 +312,7 @@ keyUsage = nonRepudiation, digitalSignature, keyEncipherment');
         return $this->getCsrContent($csrPath);
     }
 
-    private function getCsrContent($csrPath) {
+    protected function getCsrContent($csrPath) {
         $csr = file_get_contents($csrPath);
 
         preg_match('~REQUEST-----(.*)-----END~s', $csr, $matches);
@@ -320,7 +320,7 @@ keyUsage = nonRepudiation, digitalSignature, keyEncipherment');
         return trim(Base64UrlSafeEncoder::encode(base64_decode($matches[1])));
     }
 
-    private function generateKey($outputDirectory)
+    protected function generateKey($outputDirectory)
     {
         $res = openssl_pkey_new(array(
             "private_key_type" => OPENSSL_KEYTYPE_RSA,
@@ -340,7 +340,7 @@ keyUsage = nonRepudiation, digitalSignature, keyEncipherment');
         file_put_contents($outputDirectory.'/public.pem', $details['key']);
     }
 
-    private function signedRequest($uri, array $payload)
+    protected function signedRequest($uri, array $payload)
     {
         $privateKey = $this->readPrivateKey($this->accountKeyPath);
         $details = openssl_pkey_get_details($privateKey);
@@ -441,17 +441,17 @@ interface ClientInterface
 
 class Client implements ClientInterface
 {
-    private $lastCode;
-    private $lastHeader;
+    protected $lastCode;
+    protected $lastHeader;
 
-    private $base;
+    protected $base;
 
     public function __construct($base)
     {
         $this->base = $base;
     }
 
-    private function curl($method, $url, $data = null)
+    protected function curl($method, $url, $data = null)
     {
         $headers = array('Accept: application/json', 'Content-Type: application/json');
         $handle = curl_init();


### PR DESCRIPTION
Users may want to modify some behaviour of the library in sub classes. Making the inner workings accessible make that easier.

Eg. in my case I needed to modify the getDomainPath() method.
