### PR TITLE
Some refactoring, tests, doc blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .idea/
 composer.lock
 vendor
+/test/core/ngrok/
+/test/certs/
+/test/webroot/
+/composer.phar

--- a/Lescript.php
+++ b/Lescript.php
@@ -4,8 +4,14 @@ namespace Analogic\ACME;
 
 class Lescript
 {
-    public $ca = 'https://acme-v01.api.letsencrypt.org';
-    // public $ca = 'https://acme-staging.api.letsencrypt.org'; // testing
+    /** the public API to get real certificates */
+    const API_LE = 'https://acme-v01.api.letsencrypt.org';
+    /** the test API for testing the client */
+    const API_TEST = 'https://acme-staging.api.letsencrypt.org';
+
+    /** @var string The API to use */
+    public $ca = self::API_LE;
+
     public $license = 'https://letsencrypt.org/documents/LE-SA-v1.1.1-August-1-2016.pdf';
     public $countryCode = 'CZ';
     public $state = "Czech Republic";

--- a/Lescript.php
+++ b/Lescript.php
@@ -18,12 +18,16 @@ class Lescript
     private $client;
     private $accountKeyPath;
 
-    public function __construct($certificatesDir, $webRootDir, $logger = null)
+    public function __construct($certificatesDir, $webRootDir, $logger = null, ClientInterface $client = null)
     {
         $this->certificatesDir = $certificatesDir;
         $this->webRootDir = $webRootDir;
         $this->logger = $logger;
-        $this->client = new Client($this->ca);
+        if($client !== null) {
+            $this->client = $client;
+        } else {
+            $this->client = new Client($this->ca);
+        }
         $this->accountKeyPath = $certificatesDir . '/_account/private.pem';
     }
 
@@ -379,7 +383,66 @@ keyUsage = nonRepudiation, digitalSignature, keyEncipherment');
     }
 }
 
-class Client
+interface ClientInterface
+{
+    /**
+     * Constructor
+     *
+     * @param string $base the ACME API base all relative requests are sent to
+     */
+    public function __construct($base);
+
+    /**
+     * Send a POST request
+     *
+     * @param string $url URL to post to
+     * @param array $data fields to sent via post
+     * @return array|string the parsed JSON response, raw response on error
+     */
+    public function post($url, $data);
+
+    /**
+     * @param string $url URL to request via get
+     * @return array|string the parsed JSON response, raw response on error
+     */
+    public function get($url);
+
+    /**
+     * Returns the Replay-Nonce header of the last request
+     *
+     * if no request has been made, yet. A GET on $base/directory is done and the
+     * resulting nonce returned
+     *
+     * @return mixed
+     */
+    public function getLastNonce();
+
+    /**
+     * Return the Location header of the last request
+     *
+     * returns null if last request had no location header
+     *
+     * @return string|null
+     */
+    public function getLastLocation();
+
+    /**
+     * Return the HTTP status code of the last request
+     *
+     * @return int
+     */
+    public function getLastCode();
+
+    /**
+     * Get all Link headers of the last request
+     *
+     * @return string[]
+     */
+    public function getLastLinks();
+}
+
+
+class Client implements ClientInterface
 {
     private $lastCode;
     private $lastHeader;

--- a/Lescript.php
+++ b/Lescript.php
@@ -13,13 +13,13 @@ class Lescript
     public $contact = array(); // optional
     // public $contact = array("mailto:cert-admin@example.com", "tel:+12025551212")
 
-    private $certificatesDir;
-    private $webRootDir;
+    protected $certificatesDir;
+    protected $webRootDir;
 
     /** @var \Psr\Log\LoggerInterface */
-    private $logger;
-    private $client;
-    private $accountKeyPath;
+    protected $logger;
+    protected $client;
+    protected $accountKeyPath;
 
     public function __construct($certificatesDir, $webRootDir, $logger = null, ClientInterface $client = null)
     {
@@ -226,7 +226,7 @@ class Lescript
         $this->log("Done !!§§!");
     }
 
-    private function readPrivateKey($path)
+    protected function readPrivateKey($path)
     {
         if (($key = openssl_pkey_get_private('file://' . $path)) === FALSE) {
             throw new \RuntimeException(openssl_error_string());
@@ -235,18 +235,18 @@ class Lescript
         return $key;
     }
 
-    private function parsePemFromBody($body)
+    protected function parsePemFromBody($body)
     {
         $pem = chunk_split(base64_encode($body), 64, "\n");
         return "-----BEGIN CERTIFICATE-----\n" . $pem . "-----END CERTIFICATE-----\n";
     }
 
-    private function getDomainPath($domain)
+    protected function getDomainPath($domain)
     {
         return $this->certificatesDir . '/' . $domain . '/';
     }
 
-    private function postNewReg()
+    protected function postNewReg()
     {
         $this->log('Sending registration to letsencrypt server');
 
@@ -261,7 +261,7 @@ class Lescript
         );
     }
 
-    private function generateCSR($privateKey, array $domains)
+    protected function generateCSR($privateKey, array $domains)
     {
         $domain = reset($domains);
         $san = implode(",", array_map(function ($dns) {
@@ -312,7 +312,7 @@ keyUsage = nonRepudiation, digitalSignature, keyEncipherment');
         return $this->getCsrContent($csrPath);
     }
 
-    private function getCsrContent($csrPath) {
+    protected function getCsrContent($csrPath) {
         $csr = file_get_contents($csrPath);
 
         preg_match('~REQUEST-----(.*)-----END~s', $csr, $matches);
@@ -320,7 +320,7 @@ keyUsage = nonRepudiation, digitalSignature, keyEncipherment');
         return trim(Base64UrlSafeEncoder::encode(base64_decode($matches[1])));
     }
 
-    private function generateKey($outputDirectory)
+    protected function generateKey($outputDirectory)
     {
         $res = openssl_pkey_new(array(
             "private_key_type" => OPENSSL_KEYTYPE_RSA,
@@ -340,7 +340,7 @@ keyUsage = nonRepudiation, digitalSignature, keyEncipherment');
         file_put_contents($outputDirectory.'/public.pem', $details['key']);
     }
 
-    private function signedRequest($uri, array $payload)
+    protected function signedRequest($uri, array $payload)
     {
         $privateKey = $this->readPrivateKey($this->accountKeyPath);
         $details = openssl_pkey_get_details($privateKey);
@@ -441,17 +441,17 @@ interface ClientInterface
 
 class Client implements ClientInterface
 {
-    private $lastCode;
-    private $lastHeader;
+    protected $lastCode;
+    protected $lastHeader;
 
-    private $base;
+    protected $base;
 
     public function __construct($base)
     {
         $this->base = $base;
     }
 
-    private function curl($method, $url, $data = null)
+    protected function curl($method, $url, $data = null)
     {
         $headers = array('Accept: application/json', 'Content-Type: application/json');
         $handle = curl_init();

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
     "phpunit/phpunit": "5.5.*"
   },
   "autoload": {
-    "files": ["Lescript.php"],
     "psr-4": {
+      "Analogic\\ACME\\": "src",
       "Analogic\\ACME\\test\\": "test"
     }
   }

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,13 @@
     "ext-openssl": "*"
   },
   "require-dev": {
-    "psr/log": "^1"
+    "psr/log": "^1",
+    "phpunit/phpunit": "5.5.*"
   },
   "autoload": {
-    "files": ["Lescript.php"]
+    "files": ["Lescript.php"],
+    "psr-4": {
+      "Analogic\\ACME\\test\\": "test"
+    }
   }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,19 @@
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.5/phpunit.xsd"
+        backupGlobals="true"
+        backupStaticAttributes="false"
+        bootstrap="./test/core/Runner.php"
+        cacheTokens="false"
+        colors="true"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+                    verbose="true"
+>
+    <testsuites>
+        <testsuite name="My Test Suite">
+            <directory suffix=".test.php">./test/tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Base64UrlSafeEncoder.php
+++ b/src/Base64UrlSafeEncoder.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Analogic\ACME;
+
+/**
+ * URL safe Base64 encoding/decoding as described in RFC 7515
+ *
+ * @link https://tools.ietf.org/html/rfc7515#appendix-C
+ */
+class Base64UrlSafeEncoder
+{
+    /**
+     * @param string $input
+     * @return string
+     */
+    public static function encode($input)
+    {
+        return str_replace('=', '', strtr(base64_encode($input), '+/', '-_'));
+    }
+
+    /**
+     * @param string $input
+     * @return string
+     */
+    public static function decode($input)
+    {
+        $remainder = strlen($input) % 4;
+        if ($remainder) {
+            $padlen = 4 - $remainder;
+            $input .= str_repeat('=', $padlen);
+        }
+        return base64_decode(strtr($input, '-_', '+/'));
+    }
+}

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Analogic\ACME;
+
+/**
+ * Defines the features of the HTTP client to communicate with LE
+ */
+interface ClientInterface
+{
+    /**
+     * Constructor
+     *
+     * @param string $base the ACME API base all relative requests are sent to
+     */
+    public function __construct($base);
+
+    /**
+     * Send a POST request
+     *
+     * @param string $url URL to post to
+     * @param array $data fields to sent via post
+     * @return array|string the parsed JSON response, raw response on error
+     */
+    public function post($url, $data);
+
+    /**
+     * @param string $url URL to request via get
+     * @return array|string the parsed JSON response, raw response on error
+     */
+    public function get($url);
+
+    /**
+     * Returns the Replay-Nonce header of the last request
+     *
+     * if no request has been made, yet. A GET on $base/directory is done and the
+     * resulting nonce returned
+     *
+     * @return mixed
+     */
+    public function getLastNonce();
+
+    /**
+     * Return the Location header of the last request
+     *
+     * returns null if last request had no location header
+     *
+     * @return string|null
+     */
+    public function getLastLocation();
+
+    /**
+     * Return the HTTP status code of the last request
+     *
+     * @return int
+     */
+    public function getLastCode();
+
+    /**
+     * Get all Link headers of the last request
+     *
+     * @return string[]
+     */
+    public function getLastLinks();
+}

--- a/src/CurlClient.php
+++ b/src/CurlClient.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Analogic\ACME;
+
+/**
+ * HTTP Client implementation based on the Curl Extension
+ */
+class CurlClient implements ClientInterface
+{
+    /** @var string api base */
+    protected $base;
+
+    /** @var  int last HTTP status code */
+    protected $lastCode;
+    /** @var  string last HTTP headers */
+    protected $lastHeader;
+
+    /**
+     * CurlClient constructor.
+     * @param string $base
+     */
+    public function __construct($base)
+    {
+        $this->base = $base;
+    }
+
+    /**
+     * Executes a HTTP request via curl
+     *
+     * @param string $method HTTP method (GET/POST)
+     * @param string $url URL to connect to
+     * @param string $data POST body
+     * @return string/array the parsed JSON response, raw body on errors
+     */
+    protected function curl($method, $url, $data = null)
+    {
+        $headers = array('Accept: application/json', 'Content-Type: application/json');
+        $handle = curl_init();
+        curl_setopt($handle, CURLOPT_URL, preg_match('~^http~', $url) ? $url : $this->base . $url);
+        curl_setopt($handle, CURLOPT_HTTPHEADER, $headers);
+        curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($handle, CURLOPT_HEADER, true);
+
+        switch ($method) {
+            case 'GET':
+                break;
+            case 'POST':
+                curl_setopt($handle, CURLOPT_POST, true);
+                curl_setopt($handle, CURLOPT_POSTFIELDS, $data);
+                break;
+        }
+        $response = curl_exec($handle);
+
+        if (curl_errno($handle)) {
+            throw new \RuntimeException('Curl: ' . curl_error($handle));
+        }
+
+        $header_size = curl_getinfo($handle, CURLINFO_HEADER_SIZE);
+
+        $header = substr($response, 0, $header_size);
+        $body = substr($response, $header_size);
+
+        $this->lastHeader = $header;
+        $this->lastCode = curl_getinfo($handle, CURLINFO_HTTP_CODE);
+
+        $data = json_decode($body, true);
+        return $data === null ? $body : $data;
+    }
+
+    public function post($url, $data)
+    {
+        return $this->curl('POST', $url, $data);
+    }
+
+    public function get($url)
+    {
+        return $this->curl('GET', $url);
+    }
+
+    public function getLastNonce()
+    {
+        if (preg_match('~Replay\-Nonce: (.+)~i', $this->lastHeader, $matches)) {
+            return trim($matches[1]);
+        }
+
+        $this->curl('GET', '/directory');
+        return $this->getLastNonce();
+    }
+
+    public function getLastLocation()
+    {
+        if (preg_match('~Location: (.+)~i', $this->lastHeader, $matches)) {
+            return trim($matches[1]);
+        }
+        return null;
+    }
+
+    public function getLastCode()
+    {
+        return $this->lastCode;
+    }
+
+    public function getLastLinks()
+    {
+        preg_match_all('~Link: <(.+)>;rel="up"~', $this->lastHeader, $matches);
+        return $matches[1];
+    }
+}

--- a/src/Lescript.php
+++ b/src/Lescript.php
@@ -8,24 +8,35 @@ class Lescript
     const API_LE = 'https://acme-v01.api.letsencrypt.org';
     /** the test API for testing the client */
     const API_TEST = 'https://acme-staging.api.letsencrypt.org';
+    /** default license agreement */
+    const LICENSE = 'https://letsencrypt.org/documents/LE-SA-v1.1.1-August-1-2016.pdf';
 
     /** @var string The API to use */
     public $ca = self::API_LE;
 
-    public $license = 'https://letsencrypt.org/documents/LE-SA-v1.1.1-August-1-2016.pdf';
-    public $countryCode = 'CZ';
-    public $state = "Czech Republic";
-    public $challenge = 'http-01'; // http-01 challange only
-    public $contact = array(); // optional
-    // public $contact = array("mailto:cert-admin@example.com", "tel:+12025551212")
+    /** @var string the challenge type to verify domains. http-01 only currently */
+    public $challenge = 'http-01';
 
+    /** @var string the license the user agreed to */
+    public $license = self::LICENSE;
+    /** @var string the country code, the user is registering from */
+    public $countryCode = 'CZ';
+    /** @var string the country, the user is registering from */
+    public $state = "Czech Republic";
+    /** @var array contact details of the user (optiona). eg: array("mailto:cert-admin@example.com", "tel:+12025551212") */
+    public $contact = array(); // optional
+
+    /** @var string where to store certificates */
     protected $certificatesDir;
+    /** @var string where to place challenge tokens (parent of .well-known/acme-challenge/) */
     protected $webRootDir;
+    /** @var string defaults to $certificatesDir/_account/private.pem */
+    protected $accountKeyPath;
 
     /** @var \Psr\Log\LoggerInterface */
     protected $logger;
+    /** @var ClientInterface */
     protected $client;
-    protected $accountKeyPath;
 
     /**
      * Lescript constructor.

--- a/test/core/Runner.php
+++ b/test/core/Runner.php
@@ -1,0 +1,242 @@
+<?php
+
+namespace Analogic\ACME\test\core;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+/**
+ * Class Runner
+ *
+ * Manages the local http server and the ngrok tunnel connections. Also provides utility functions
+ * for the tests
+ */
+class Runner
+{
+    /**
+     * @var string[] list of tunnels
+     */
+    protected $ngrokhosts = array();
+
+    /**
+     * Run the servers
+     */
+    public function __construct()
+    {
+        $this->runNgrok(8080);
+        $this->runNgrok(8080);
+        $this->runNgrok(8080);
+        $this->runHTTPServer(8080);
+    }
+
+    /**
+     * Returns the webroot
+     *
+     * @return string
+     */
+    public function getRoot()
+    {
+        $dir = __DIR__ . '/../webroot/';
+        if (!is_dir($dir)) {
+            if (!mkdir($dir)) {
+                throw new \RuntimeException("$dir not creatable");
+            }
+        }
+        return $dir;
+    }
+
+    /**
+     * Returns the webroot
+     *
+     * @return string
+     */
+    public function getCertdir()
+    {
+        $dir = __DIR__ . '/../certs/';
+        if (!is_dir($dir)) {
+            if (!mkdir($dir)) {
+                throw new \RuntimeException("$dir not creatable");
+            }
+        }
+        return $dir;
+    }
+
+    /**
+     * Get the tunnel names
+     *
+     * @return string[]
+     */
+    public function getNgrokHosts()
+    {
+        return $this->ngrokhosts;
+    }
+
+
+    /**
+     * Run ngrok in a forked process and get the host name via API
+     *
+     * @param int $port the http port to tunnel
+     */
+    protected function runNgrok($port)
+    {
+        static $apiport = 4040;
+
+        echo "Starting ngrok tunnel...\n";
+        $ngrok = $this->getNgrok();
+        $pid = pcntl_fork();
+        if ($pid == 1) {
+            throw new \RuntimeException('Failed to fork');
+        } else {
+            if ($pid) {
+                //child
+                pcntl_exec($ngrok, array('http', $port, '--log', 'stderr', '--log-level', 'error'));
+            } else {
+                //parent
+                sleep(2);
+                $info = file_get_contents("http://localhost:$apiport/api/tunnels");
+                $info = json_decode($info, true);
+                if (!$info) {
+                    throw new \RuntimeException('Failed to connect to ngrok API');
+                }
+
+                foreach ($info['tunnels'] as $tunnel) {
+                    if ($tunnel['proto'] == 'https') {
+                        continue;
+                    }
+                    $this->ngrokhosts[] = parse_url($tunnel['public_url'], PHP_URL_HOST);
+                }
+                // automatically shut down ngrok when the script ends
+                register_shutdown_function(
+                    function () use ($pid) {
+                        posix_kill($pid, SIGINT);
+                    }
+                );
+
+                $apiport++; // next call uses next port
+            }
+        }
+    }
+
+    /**
+     * @param int $port The port to run on
+     */
+    protected function runHTTPServer($port)
+    {
+        echo "Starting http server...\n";
+        $root = $this->getRoot();
+        $pid = pcntl_fork();
+        if ($pid) {
+            // suppress output
+            fclose(STDOUT);
+            fclose(STDERR);
+            //child
+            pcntl_exec(PHP_BINARY, array('-S', "localhost:$port", '-t', $root));
+        } else {
+            //parent
+            sleep(2);
+
+            // automatically shut down httpd when the script ends
+            register_shutdown_function(
+                function () use ($pid) {
+                    posix_kill($pid, SIGINT);
+                }
+            );
+        }
+    }
+
+    /**
+     * Downloads the correct ngrok binary, if none available, yet
+     *
+     * @return string path to the ngrok binary
+     * @throws \RuntimeException
+     */
+    protected function getNgrok()
+    {
+        $ngrokdir = __DIR__ . '/ngrok';
+
+        if (!is_dir($ngrokdir)) {
+            if (!mkdir($ngrokdir)) {
+                throw new \RuntimeException("$ngrokdir not cretable");
+            }
+        }
+
+        $bin = $this->getBinaryName();
+        $ngrok = $ngrokdir . '/' . $bin;
+        $url = "https://bin.equinox.io/c/4VmDzA7iaHb/$bin";
+        $url = preg_replace('/\.exe$/', '', $url);
+
+        if (!file_exists($ngrok)) {
+            echo "Downloading ngrok...\n";
+            file_put_contents($ngrok, file_get_contents($url));
+        }
+
+        if (!file_exists($ngrok)) {
+            throw new \RuntimeException("Couldn't download $ngrok");
+        }
+
+        if (!is_executable($ngrok)) {
+            chmod($ngrok, 0755);
+        }
+        if (!is_executable($ngrok)) {
+            throw new \RuntimeException("Can't execute $ngrok");
+        }
+
+        return $ngrok;
+    }
+
+    /**
+     * Figure out what binary is needed on this platform
+     *
+     * @return string
+     * @throws \RuntimeException when the platform can not be determined
+     */
+    protected function getBinaryName()
+    {
+        $ext = '';
+        $os = php_uname('s');
+        if (preg_match('/darwin/i', $os)) {
+            $os = 'darwin';
+        } elseif (preg_match('/win/i', $os)) {
+            $os = 'windows';
+            $ext = '.exe';
+        } elseif (preg_match('/linux/i', $os)) {
+            $os = 'linux';
+        } elseif (preg_match('/freebsd/i', $os)) {
+            $os = 'freebsd';
+        } elseif (preg_match('/openbsd/i', $os)) {
+            $os = 'openbsd';
+        } elseif (preg_match('/netbsd/i', $os)) {
+            $os = 'netbsd';
+        } elseif (preg_match('/(solaris|netbsd)/i', $os)) {
+            $os = 'freebsd';
+        } else {
+            throw new \RuntimeException('Unknown platform');
+        }
+        $arch = php_uname('m');
+        if ($arch == 'x86_64') {
+            $arch = 'amd64';
+        } elseif (preg_match('/arm/i', $arch)) {
+            $arch = 'amd';
+        } else {
+            $arch = '386';
+        }
+        return "ngrok-stable-$os-$arch$ext";
+    }
+
+    /**
+     * recursively delete a directory
+     *
+     * @param $dir
+     * @return bool
+     * @link http://php.net/manual/en/function.rmdir.php#110489
+     */
+    public static function delTree($dir)
+    {
+        $files = array_diff(scandir($dir), array('.', '..'));
+        foreach ($files as $file) {
+            (is_dir("$dir/$file")) ? self::delTree("$dir/$file") : unlink("$dir/$file");
+        }
+        return rmdir($dir);
+    }
+}
+
+$RUNNER = new Runner();

--- a/test/core/TestCase.php
+++ b/test/core/TestCase.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Analogic\ACME\test\core;
+
+abstract class TestCase extends \PHPUnit_Framework_TestCase
+{
+
+    protected $certdir;
+    protected $root;
+    protected $hosts;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        global $RUNNER;
+
+        $this->root = $RUNNER->getRoot();
+        $this->certdir = $RUNNER->getCertdir();
+        $this->hosts = $RUNNER->getNgrokHosts();
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+        Runner::delTree($this->certdir);
+        Runner::delTree($this->root);
+    }
+
+}

--- a/test/tests/Lescript.test.php
+++ b/test/tests/Lescript.test.php
@@ -8,25 +8,31 @@ use Psr\Log\NullLogger;
 
 class Lescript_test extends TestCase
 {
+    /** @var  Lescript */
+    protected $lescript;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->lescript = new Lescript($this->certdir, $this->root, new NullLogger());
+        $this->lescript->ca = Lescript::API_TEST;
+        $this->lescript->initAccount();
+    }
 
     public function test_initAccount()
     {
-        $lescript = new Lescript($this->certdir, $this->root, new NullLogger());
-        $lescript->initAccount();
+        // account init happened in setup already
         $this->assertFileExists($this->certdir . '/_account/private.pem');
         $this->assertFileExists($this->certdir . '/_account/public.pem');
 
         // existing key should not be overwritten
         $md5 = md5(file_get_contents($this->certdir . '/_account/private.pem'));
-        $lescript->initAccount();
+        $this->lescript->initAccount();
         $this->assertEquals($md5, md5(file_get_contents($this->certdir . '/_account/private.pem')));
     }
 
     public function test_Sign() {
-        $lescript = new Lescript($this->certdir, $this->root, new NullLogger());
-        $lescript->initAccount();
-
-        $lescript->signDomains(array($this->hosts[0]));
+        $this->lescript->signDomains(array($this->hosts[0]));
 
         $outdir = $this->certdir.'/'.$this->hosts[0];
         $this->assertFileExists($outdir.'/cert.pem');
@@ -47,10 +53,7 @@ class Lescript_test extends TestCase
     }
 
     public function test_SAN() {
-        $lescript = new Lescript($this->certdir, $this->root, new NullLogger());
-        $lescript->initAccount();
-
-        $lescript->signDomains($this->hosts);
+        $this->lescript->signDomains($this->hosts);
 
         $outdir = $this->certdir.'/'.$this->hosts[0];
         $this->assertFileExists($outdir.'/cert.pem');

--- a/test/tests/Lescript.test.php
+++ b/test/tests/Lescript.test.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Analogic\ACME\test\tests;
+
+use Analogic\ACME\Lescript;
+use Analogic\ACME\test\core\TestCase;
+use Psr\Log\NullLogger;
+
+class Lescript_test extends TestCase
+{
+
+    public function test_initAccount()
+    {
+
+        $lescript = new Lescript($this->certdir, $this->root, new NullLogger());
+        $lescript->initAccount();
+        $this->assertFileExists($this->certdir . '/_account/private.pem');
+
+    }
+
+}

--- a/test/tests/Lescript.test.php
+++ b/test/tests/Lescript.test.php
@@ -11,11 +11,71 @@ class Lescript_test extends TestCase
 
     public function test_initAccount()
     {
-
         $lescript = new Lescript($this->certdir, $this->root, new NullLogger());
         $lescript->initAccount();
         $this->assertFileExists($this->certdir . '/_account/private.pem');
+        $this->assertFileExists($this->certdir . '/_account/public.pem');
 
+        // existing key should not be overwritten
+        $md5 = md5(file_get_contents($this->certdir . '/_account/private.pem'));
+        $lescript->initAccount();
+        $this->assertEquals($md5, md5(file_get_contents($this->certdir . '/_account/private.pem')));
+    }
+
+    public function test_Sign() {
+        $lescript = new Lescript($this->certdir, $this->root, new NullLogger());
+        $lescript->initAccount();
+
+        $lescript->signDomains(array($this->hosts[0]));
+
+        $outdir = $this->certdir.'/'.$this->hosts[0];
+        $this->assertFileExists($outdir.'/cert.pem');
+        $this->assertFileExists($outdir.'/chain.pem');
+        $this->assertFileExists($outdir.'/fullchain.pem');
+        $this->assertFileExists($outdir.'/last.csr');
+        $this->assertFileExists($outdir.'/private.pem');
+        $this->assertFileExists($outdir.'/public.pem');
+
+        $info = openssl_x509_parse(file_get_contents($outdir.'/cert.pem'));
+
+        $this->assertEquals('Let\'s Encrypt', $info['issuer']['O']);
+        $this->assertEquals("/CN={$this->hosts[0]}", $info['name']);
+        $this->assertEquals($this->hosts[0], $info['subject']['CN']);
+        $this->assertTrue(($info['validTo_time_t'] - time()) > 60*60*24*89, 'certificate should be valid for 90 days');
+
+        $this->assertEquals('DNS:'.$this->hosts[0], $info['extensions']['subjectAltName']);
+    }
+
+    public function test_SAN() {
+        $lescript = new Lescript($this->certdir, $this->root, new NullLogger());
+        $lescript->initAccount();
+
+        $lescript->signDomains($this->hosts);
+
+        $outdir = $this->certdir.'/'.$this->hosts[0];
+        $this->assertFileExists($outdir.'/cert.pem');
+        $this->assertFileExists($outdir.'/chain.pem');
+        $this->assertFileExists($outdir.'/fullchain.pem');
+        $this->assertFileExists($outdir.'/last.csr');
+        $this->assertFileExists($outdir.'/private.pem');
+        $this->assertFileExists($outdir.'/public.pem');
+
+        $info = openssl_x509_parse(file_get_contents($outdir.'/cert.pem'));
+
+        $this->assertEquals('Let\'s Encrypt', $info['issuer']['O']);
+        $this->assertEquals("/CN={$this->hosts[0]}", $info['name']);
+        $this->assertEquals($this->hosts[0], $info['subject']['CN']);
+        $this->assertTrue(($info['validTo_time_t'] - time()) > 60*60*24*89, 'certificate should be valid for 90 days');
+
+        $san = array(
+            'DNS:'.$this->hosts[0],
+            'DNS:'.$this->hosts[1],
+            'DNS:'.$this->hosts[2],
+        );
+        sort($san);
+        $san = join(', ', $san);
+
+        $this->assertEquals($san, $info['extensions']['subjectAltName']);
     }
 
 }

--- a/test/tests/Runner.test.php
+++ b/test/tests/Runner.test.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Analogic\ACME\test\tests;
+
+use Analogic\ACME\test\core\TestCase;
+
+class Runner_test extends TestCase
+{
+
+    /**
+     * Ensure tunnels are up and local http is working and the test object is set up correct
+     */
+    public function test_tunnels()
+    {
+        $this->assertTrue(is_dir($this->root));
+        $this->assertTrue(is_dir($this->certdir));
+        $this->assertEquals(3, count($this->hosts));
+
+        file_put_contents($this->root . '/test.txt', 'test');
+        for ($host = 0; $host < 3; $host++) {
+            $domain = $this->hosts[$host];
+            $this->assertStringEndsWith('ngrok.io', $domain);
+            $data = file_get_contents("http://$domain/test.txt");
+            $this->assertEquals('test', $data);
+        }
+    }
+
+}


### PR DESCRIPTION
This refactors the library into separate files per class as suggested by @tm1000 in #18. It also introduces  unit testing with some initial tests. More tests at a deeper level would make sense though (currently it just checks the overall outcome). I also added doc blocks to make things bit easier to understand and for better type hinting in IDEs. This also incorporates #23. After merging, automated unit testing at travis-ci should be set up.

If you're not interested in this, feel free to close.
