### PR TITLE
Remove the simple self check

### DIFF
--- a/Lescript.php
+++ b/Lescript.php
@@ -94,7 +94,7 @@ class Lescript
         $response = $this->signedRequest(
             $this->urlNewOrder,
             array("identifiers" => array_map(
-                function ($domain) { return array("type" => "dns", "value" => $domain);}, 
+                function ($domain) { return array("type" => "dns", "value" => $domain);},
                 $domains
                 ))
         );
@@ -147,13 +147,8 @@ class Lescript
 
             $this->log("Token for $domain saved at $tokenPath and should be available at $uri");
 
-            // simple self check
-            if ($payload !== trim(@file_get_contents($uri))) {
-                throw new RuntimeException("Please check $uri - token not available");
-            }
-
             $this->log("Sending request to challenge");
-                
+
 
             // send request to challenge
             $allowed_loops = 30;
@@ -186,7 +181,7 @@ class Lescript
             $this->log("Verification ended with status: ${result['status']}");
 
             @unlink($tokenPath);
-        } 
+        }
 
                 // requesting certificate
         // ----------------------
@@ -211,7 +206,7 @@ class Lescript
         if ($this->client->getLastCode() > 299 || $this->client->getLastCode() < 200) {
             throw new RuntimeException("Invalid response code: " . $this->client->getLastCode() . ", " . json_encode($finalizeResponse));
         }
-        
+
         $location = $finalizeResponse['certificate'];
 
         // waiting loop
@@ -554,7 +549,7 @@ class Client implements ClientInterface
         if(preg_match('~Replay-Nonce: (.+)~i', $this->lastHeader, $matches)) {
             return trim($matches[1]);
         }
-        
+
         throw new RuntimeException("We don't have nonce");
     }
 


### PR DESCRIPTION
The simple self check is too naive and fails behind a proxy. It's common
to run an email server behind a proxy.

I don't think the self check has much value in its current state,
because the actual renewal request will fail with a similar error if the
user didn't configure things correctly. The self check in its current
state does more harm than good, due to false negatives.

It's better to focus on error handling rather than trying to catch
errors like these before the request even took place. Many different
errors can occur when requesting a certificate, and the ACME protocol
will report these. If you make sure that these errors are displayed
correctly, there should be no need for this self check.